### PR TITLE
Fix tmux clipboard binding typo

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -8,7 +8,7 @@ bind-key C-a send-prefix
 
 set-window-option -g mode-keys vi
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi v send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboar'
+bind -T copy-mode-vi v send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
 
 bind r source-file "$HOME/.config/tmux/tmux.conf" \; display-message "tmux.conf reloaded"
 

--- a/arch/.config/tmux/tmux.conf
+++ b/arch/.config/tmux/tmux.conf
@@ -9,7 +9,7 @@ bind-key C-a send-prefix
 set-window-option -g mode-keys vi
 setw -g mode-keys vi
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi v send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboar'
+bind -T copy-mode-vi v send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
 
 bind r source-file "$HOME/.config/tmux/tmux.conf" \; display-message "tmux.conf reloaded"
 


### PR DESCRIPTION
## Summary
- fix `xclip` selection argument typo in tmux configs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f6f8fa80832da4a1d96ed808c397